### PR TITLE
Fix desktop file path on Linux (#95)

### DIFF
--- a/src/main/java/com/pryzmm/splitself/file/DesktopFileUtil.java
+++ b/src/main/java/com/pryzmm/splitself/file/DesktopFileUtil.java
@@ -9,11 +9,22 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 
 public class DesktopFileUtil {
-
     public static void createFileOnDesktop(String fileName, String content) {
+        // getHomeDirectory() return user's Desktop on Windows
+        // but on UNIX/Linux it will return user's home directory
+        
+        // https://stackoverflow.com/questions/570401/in-java-under-windows-how-do-i-find-a-redirected-desktop-folder#comment10308923_570536
         File desktop = FileSystemView.getFileSystemView().getHomeDirectory();
         File file = new File(desktop, fileName);
 
+        if (System.getProperty("os.name").toLowerCase().contains("win")) {
+            desktop = desktop;
+        } else {
+            // os isn't win put Desktop
+            desktop = new File(desktop, "Desktop");
+        }
+
+        SplitSelf.LOGGER.info("file: " + desktop);
         try {
             if (!file.exists()) {
                 boolean created = file.createNewFile();

--- a/src/main/java/com/pryzmm/splitself/file/DesktopFileUtil.java
+++ b/src/main/java/com/pryzmm/splitself/file/DesktopFileUtil.java
@@ -9,22 +9,24 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 
 public class DesktopFileUtil {
-    public static void createFileOnDesktop(String fileName, String content) {
+    private static File getDesktopDirectory() {
         // getHomeDirectory() return user's Desktop on Windows
         // but on UNIX/Linux it will return user's home directory
         
         // https://stackoverflow.com/questions/570401/in-java-under-windows-how-do-i-find-a-redirected-desktop-folder#comment10308923_570536
-        File desktop = FileSystemView.getFileSystemView().getHomeDirectory();
-        File file = new File(desktop, fileName);
+        File home = FileSystemView.getFileSystemView().getHomeDirectory();
 
         if (System.getProperty("os.name").toLowerCase().contains("win")) {
-            desktop = desktop;
-        } else {
-            // os isn't win put Desktop
-            desktop = new File(desktop, "Desktop");
+            return home;
         }
 
-        SplitSelf.LOGGER.info("file: " + desktop);
+        return new File(home, "Desktop");
+    }
+
+    public static void createFileOnDesktop(String fileName, String content) {
+        File desktop = getDesktopDirectory();
+        File file = new File(desktop, fileName);
+
         try {
             if (!file.exists()) {
                 boolean created = file.createNewFile();
@@ -44,7 +46,7 @@ public class DesktopFileUtil {
 
     public static void cloneFileToDesktop(Identifier identifier) {
         String resourcePath = "assets/" + identifier.getNamespace() + "/" + identifier.getPath();
-        Path destination = FileSystemView.getFileSystemView().getHomeDirectory().toPath().resolve(Path.of(identifier.getPath()).getFileName());
+        Path destination = getDesktopDirectory().toPath().resolve(Path.of(identifier.getPath()).getFileName());
         try (InputStream in = DesktopFileUtil.class.getClassLoader().getResourceAsStream(resourcePath)) {
             if (in == null) throw new IOException("Resource not found: " + resourcePath);
             Files.copy(in, destination, StandardCopyOption.REPLACE_EXISTING);


### PR DESCRIPTION
This pull request fixes an issue mentioned in https://github.com/Pryzmm/Split-Self/issues/95 where files created by SplitSelf were written to user's home directory instead of the Desktop on Linux systems.

## Problem
`FileSystemView.getFileSystemView().getHomeDirectory()` does not resolve to the Desktop folder in Linux.

This result in `begin.txt` being created at `~/` instead of `~/Desktop`

Reference: https://stackoverflow.com/questions/570401/in-java-under-windows-how-do-i-find-a-redirected-desktop-folder#comment10308923_570536

## Solution
Added a simple helper method to resolve the Desktop directory. On Windows it keeps the current behavior. and on Linux/macOS it points to `~/Desktop`

## Changes
- Added `getDesktopDirectory()` helper method
- Fix file creation path in `createFileOnDesktop`
- Fix file copy destination path in `cloneFileToDesktop`